### PR TITLE
添加jsdoc注释，满足egg-ts-helper智能提示要求

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+
+# 新增更新
+
+添加egg-sequelize 多数据库源的delegate名称参数，option中添加：egg_delegate:'some_model',  即可
+
 # Egg-Sequelize-Auto
 
 Automatically generate models for [egg-sequelize](https://github.com/eggjs/egg-sequelize) via the command line.
@@ -114,7 +119,6 @@ Produces a file/files such as ./app/model/users.js which looks like:
       return Model;
     };
 
-
 ## Configuration options
 
 For the `-c, --config` option the following JSON/configuration parameters are defined by Sequelize's `options` flag within the constructor. For more info:
@@ -127,7 +131,7 @@ For the `-c, --config` option the following JSON/configuration parameters are de
 const EggSequelizeAuto = require('egg-sequelize-auto')
 const auto = new EggSequelizeAuto'database', 'user', 'pass');
 
-// start 
+// start
 auto.run(function (err) {
   if (err) throw err;
 
@@ -141,6 +145,7 @@ const auto = new EggSequelizeAuto('database', 'user', 'pass', {
     dialect: 'mysql'|'mariadb'|'sqlite'|'postgres'|'mssql',
     directory: false, // prevents the program from writing to disk
     port: 'port',
+    egg_delegate:'model'
     additional: {
         timestamps: false
         //...

--- a/lib/index.js
+++ b/lib/index.js
@@ -115,9 +115,9 @@ class EggSequelizeAuto extends SequelizeAuto {
                 var field_type = self.tables[table][field].type.toLowerCase();
                 if (field_type.indexOf('date') === 0 || field_type.indexOf('timestamp') === 0) {
                   if (_.endsWith(defaultVal, '()')) {
-                    val_text = "sequelize.fn('" + defaultVal.replace(/\(\)$/, '') + "')"
+                    val_text = "DataTypes.fn('" + defaultVal.replace(/\(\)$/, '') + "')"
                   } else if (_.includes(['current_timestamp', 'current_date', 'current_time', 'localtime', 'localtimestamp'], defaultVal.toLowerCase())) {
-                    val_text = "sequelize.literal('" + defaultVal + "')"
+                    val_text = "DataTypes.literal('" + defaultVal + "')"
                   } else {
                     val_text = quoteWrapper + val_text + quoteWrapper
                   }
@@ -129,7 +129,7 @@ class EggSequelizeAuto extends SequelizeAuto {
               if (defaultVal === null || defaultVal === undefined) {
                 return true;
               } else {
-                val_text = _.isString(val_text) && !val_text.match(/^sequelize\.[^(]+\(.*\)$/) ? SqlString.escape(_.trim(val_text, '"'), null, self.options.dialect) : val_text;
+                val_text = _.isString(val_text) && !val_text.match(/^DataTypes\.[^(]+\(.*\)$/) ? SqlString.escape(_.trim(val_text, '"'), null, self.options.dialect) : val_text;
 
                 // don't prepend N for MSSQL when building models...
                 val_text = _.trimStart(val_text, 'N')

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,9 @@ class EggSequelizeAuto extends SequelizeAuto {
         }
 
         text[table] = "/* indent size: " + self.options.indentation + " */\n\n";
+        text[table] = "/**\n";
+        text[table] = " * @param {Egg.Application} app app\n";
+        text[table] = " */\n";
         text[table] += "module.exports = app => {\n";
         text[table] += spaces + "const DataTypes = app.Sequelize;\n\n";
         var tableName = self.options.camelCase ? _.camelCase(table) : table;

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,9 +34,9 @@ class EggSequelizeAuto extends SequelizeAuto {
         }
 
         text[table] = "/* indent size: " + self.options.indentation + " */\n\n";
-        text[table] = "/**\n";
-        text[table] = " * @param {Egg.Application} app app\n";
-        text[table] = " */\n";
+        text[table] += "/**\n";
+        text[table] += " * @param {Egg.Application} app app\n";
+        text[table] += " */\n";
         text[table] += "module.exports = app => {\n";
         text[table] += spaces + "const DataTypes = app.Sequelize;\n\n";
         var tableName = self.options.camelCase ? _.camelCase(table) : table;

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,8 @@ class EggSequelizeAuto extends SequelizeAuto {
         text[table] += "module.exports = app => {\n";
         text[table] += spaces + "const DataTypes = app.Sequelize;\n\n";
         var tableName = self.options.camelCase ? _.camelCase(table) : table;
-        text[table] += spaces + "const Model = app.model.define('" + tableName + "', {\n";
+        let egg_delegate = self.options.egg_delegate || 'model';
+        text[table] += spaces + "const Model = app." + egg_delegate + ".define('" + tableName + "', {\n";
 
         _.each(fields, function(field, i) {
           var additional = self.options.additional

--- a/lib/index.js
+++ b/lib/index.js
@@ -101,6 +101,9 @@ class EggSequelizeAuto extends SequelizeAuto {
               if (self.sequelize.options.dialect === "mssql" && defaultVal && defaultVal.toLowerCase() === '(newid())') {
                 defaultVal = null; // disable adding "default value" attribute for UUID fields if generating for MS SQL
               }
+              if (self.sequelize.options.dialect === "postgres" && defaultVal && defaultVal.toLowerCase().indexOf('nextval') > -1) {
+                defaultVal = null; // disable adding "default value" attribute for UUID fields if generating for MS SQL
+              }
 
               var val_text = defaultVal;
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "egg-sequelize-auto",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "description": "Automatically generate bare sequelize models from your database, adjustment for egg",
   "main": "index.js",
   "bin": {
     "egg-sequelize-auto": "bin/egg-sequelize-auto",
-    "sequelize-auto":"bin/sequelize-auto"
+    "sequelize-auto": "bin/sequelize-auto"
   },
   "scripts": {
     "test": "node ./bin/egg-sequelize-auto -c ./config.json"


### PR DESCRIPTION
(1)添加jsdoc注释，满足egg-ts-helper智能提示要求,
(2)添加egg-sequelize 多数据库源的delegate名称参数，option中添加：egg_delegate:'someModel'